### PR TITLE
Manifest 3 Compatible

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,11 +6,11 @@
     "permissions": [
       "activeTab"
     ],
-    "web_accessible_resources": [
-        "table.html",
-        "scripts/*",
-        "styles/*"
-    ],
+    "web_accessible_resources": [{
+      "resources": ["table.html", "scripts/*", "styles/*"],
+      "matches": ["https://act.ucsd.edu/*"],
+      "use_dyanmics_url": true
+    }],
     "content_scripts": [
       {
         "matches": ["https://act.ucsd.edu/webreg2/*"],
@@ -21,5 +21,5 @@
     "browser_action": {
       "default_title": "Append Test Text"
     },
-    "manifest_version": 2
+    "manifest_version": 3
 }


### PR DESCRIPTION
Small patch to make it compatible to v3 for a potential future chrome extension? I know you stated you didn't want to do so in order to maintain compatibility to Firefox, if that's your plan you can close this pull and I can maintain a separate v3 version for an extension to make it easier for students to download and use without having to mess with dev settings.