### PR TITLE
Fixed issue with LE/DI not showing up if both on same set of days 

### DIFF
--- a/scripts/browser_action.js
+++ b/scripts/browser_action.js
@@ -418,10 +418,9 @@ class UCSDScheduleVisualizer{
         let classSubject = keyItterator.next().value;
         while(classSubject != undefined){
             let classInfo = currentClasses.get(classSubject);
-            let daysKeys = Object.keys(classInfo.days);
-            for (let i = 0; i < daysKeys.length; i++) {
-                const dayTime = classInfo.days[daysKeys[i]].time;
-                const dayKey = daysKeys[i];
+            for (let i = 0; i < classInfo.days.length; i++) {
+                const dayTime = classInfo.days[i].time;
+                const dayKey = classInfo.days[i].days;
                 // split day keys
                 let days = dayKey.split("");
                 let dates = this.textToDates(dayTime);
@@ -435,7 +434,7 @@ class UCSDScheduleVisualizer{
                     }
                     // console.log(dayCode + " - " + timeStartHour);
                     let eventObj = {
-                        subject: `${classSubject.trim()} (${classInfo.days[dayKey].building})`, 
+                        subject: `${classSubject.trim()} (${classInfo.days[i].building})`, 
                         day: dayCode, 
                         dateStart: dates.start, 
                         dateEnd: dates.end
@@ -562,9 +561,9 @@ class UCSDScheduleVisualizer{
             // handle times and days separately
     
             if(classInfoObj.days === undefined){
-                classInfoObj.days = {};
+                classInfoObj.days = [];
             }
-            classInfoObj.days[rowDays] = {time: rowTime, building: rowBuilding};
+            classInfoObj.days.push({ days: rowDays, time: rowTime, building: rowBuilding});
         }
         return classInfo;
     }


### PR DESCRIPTION
Ex: CAT 2 with both LE & DI on TuTh (see image below). When it gets to the second line, it ends up overwriting the lecture. This happened because the days property was an object, with the key being "TuTh". I changed it to use an array, so both the LE and DI will be included.
![image](https://user-images.githubusercontent.com/5413412/200692591-90917de3-b45f-4671-864a-8a392712cde4.png)
