### PR TITLE
when first time seeing class but already parsing some class no longer skips the new class

### DIFF
--- a/scripts/browser_action.js
+++ b/scripts/browser_action.js
@@ -632,6 +632,7 @@ class UCSDScheduleVisualizer{
             // if we are already tracking some class but now found row that is not "Final Exam" or "Midterm"
             else if(currentKey !== null && rowTitle){
                 currentKey = null;
+                i--;
                 continue;
             }
             // if there is a row title that is not "Final Exam" set it as currentKey


### PR DESCRIPTION
Before if parsing some class, and then encountering a new class before reaching finals or midterms, would skip the newly encountered class. Now no longer does that.